### PR TITLE
fixes the test strategy by updating changed method names

### DIFF
--- a/lib/volcanic/authenticator/warden/test.rb
+++ b/lib/volcanic/authenticator/warden/test.rb
@@ -10,8 +10,8 @@ module Volcanic::Authenticator::Warden
 
     def authenticate!
       return fail! test_message if defined?(Rails) && Rails.env.production?
-      return fail! missing_message unless token_exist?
-      return fail! invalid_message unless fetch_token == 'test'
+      return fail! missing_message unless auth_header_exist?
+      return fail! invalid_message unless fetch_auth_token == 'test'
 
       success! 'test'
     end


### PR DESCRIPTION
The following methods had been renamed in the `StrategyHelper` causing the test strategy to fail.
`token_exist?` => `auth_header_exist?`
`fetch_token` => `fetch_auth_token`

This updates said method names.