### PR TITLE
Updated #in_scope? for Permission

### DIFF
--- a/lib/volcanic/authenticator/v1/privilege.rb
+++ b/lib/volcanic/authenticator/v1/privilege.rb
@@ -26,7 +26,7 @@ module Volcanic::Authenticator
       # Returns
       # => boolean
       def in_scope?(vrn)
-        Scope.new(scope).include?(vrn)
+        Scope.parse(scope).include?(vrn)
       end
 
       def permissions


### PR DESCRIPTION
### What?

Updated `permission.in_scope?(vrn)` to call `Scope.parse(scope)`, not `Scope.new(scope)`.