### PR TITLE
Sorting of Privileges

### DIFF
--- a/lib/volcanic/authenticator/v1/privilege.rb
+++ b/lib/volcanic/authenticator/v1/privilege.rb
@@ -22,11 +22,28 @@ module Volcanic::Authenticator
         @allow = allow
       end
 
+      def <=>(other)
+        scope1 = Scope.parse(scope)
+        scope2 = Scope.parse(other.scope)
+
+        if scope1 == scope2
+          allow_bool <=> other.allow_bool
+        else
+          scope1 <=> scope2
+        end
+      end
+
       # Compare provided VRN with the scope we have
       # Returns
       # => boolean
       def in_scope?(vrn)
         Scope.parse(scope).include?(vrn)
+      end
+
+      # Without casting to an integer we get a comparison error when
+      # sorting using the spaceship (<=>) operator.
+      def allow_bool
+        allow == true ? 1 : 0
       end
 
       def permissions

--- a/spec/volcanic/authenticator/v1/scope_spec.rb
+++ b/spec/volcanic/authenticator/v1/scope_spec.rb
@@ -153,5 +153,69 @@ RSpec.describe Volcanic::Authenticator::V1::Scope do
         end
       end
     end
+
+    describe '.score' do
+      subject { described_class.parse(scope).specificity_score }
+
+      context 'for stack_id' do
+        context 'with a wildcard' do
+          let(:scope) { 'vrn:*:*:*/*' }
+
+          it { is_expected.to eq(0) }
+        end
+        context 'with a value' do
+          let(:scope) { 'vrn:local:*:*/*' }
+
+          it { is_expected.to eq(1) }
+        end
+      end
+
+      context 'for dataset_id' do
+        context 'with a wildcard' do
+          let(:scope) { 'vrn:*:*:*/*' }
+
+          it { is_expected.to eq(0) }
+        end
+        context 'with a value' do
+          let(:scope) { 'vrn:*:-1:*/*' }
+
+          it { is_expected.to eq(2) }
+        end
+      end
+
+      context 'for resource' do
+        context 'with a wildcard' do
+          let(:scope) { 'vrn:*:*:*/*' }
+
+          it { is_expected.to eq(0) }
+        end
+        context 'with a value' do
+          let(:scope) { 'vrn:*:*:jobs/*' }
+
+          it { is_expected.to eq(3) }
+        end
+      end
+
+      context 'for resource_id' do
+        context 'with a wildcard' do
+          let(:scope) { 'vrn:*:*:jobs/*' }
+
+          it { is_expected.to eq(3) }
+        end
+        context 'with a value' do
+          let(:scope) { 'vrn:*:-1:jobs/14' }
+
+          it { is_expected.to eq(9) }
+        end
+      end
+
+      context 'for resource_id with qualifiers' do
+        context 'with a value' do
+          let(:scope) { 'vrn:*:-1:jobs/14?this=that' }
+
+          it { is_expected.to eq(14.0) }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### What?

Privileges need to be sorted by relevance.  This has been done by generating a score for each VRN and sorting based on that.

* Updating the sorting of privileges to be based on scope scoring.