### PR TITLE
:mag: Allow a scope to return itself without qualifiers

### DIFF
--- a/lib/volcanic/authenticator/v1/scope.rb
+++ b/lib/volcanic/authenticator/v1/scope.rb
@@ -49,6 +49,12 @@ module Volcanic::Authenticator
         base
       end
 
+      def vrn_without_qualifiers
+        base = "vrn:#{stack_id}:#{dataset_id}:#{resource}"
+        base += "/#{resource_id}" if resource_id
+        base
+      end
+
       def <=>(other)
         specificity_score <=> other.specificity_score
       end

--- a/spec/volcanic/authenticator/v1/scope_spec.rb
+++ b/spec/volcanic/authenticator/v1/scope_spec.rb
@@ -111,6 +111,26 @@ RSpec.describe Volcanic::Authenticator::V1::Scope do
       end
     end
 
+    describe '.vrn_without_qualifiers' do
+      subject { described_class.parse(scope).vrn_without_qualifiers }
+
+      context 'with qualifiers' do
+        let(:scope) { 'vrn:local:-1:identity/2?foo=bar' }
+
+        it 'doesn\'t return qualifiers' do
+          expect(subject).to eq('vrn:local:-1:identity/2')
+        end
+      end
+
+      context 'without qualifiers' do
+        let(:scope) { 'vrn:local:-1:identity/2' }
+
+        it 'doesn\'t return qualifiers' do
+          expect(subject).to eq(scope)
+        end
+      end
+    end
+
     describe '.include?(other)' do
       subject { described_class.parse(scope).include?(other) }
 


### PR DESCRIPTION
### What?

Method on scope to allow return the VRN without any qualifiers.  To be used in the BasePolicy for filtering scopes.