### PR TITLE
Cast to string if we have a resource_id

### DIFF
--- a/lib/volcanic/authenticator/v1/privilege.rb
+++ b/lib/volcanic/authenticator/v1/privilege.rb
@@ -34,7 +34,7 @@ module Volcanic::Authenticator
       # Returns
       # => boolean
       def in_scope?(vrn)
-        Scope.parse(scope).include?(vrn)
+        scope.include?(vrn)
       end
 
       # Without casting to an integer we get a comparison error when

--- a/lib/volcanic/authenticator/v1/scope.rb
+++ b/lib/volcanic/authenticator/v1/scope.rb
@@ -26,9 +26,9 @@ module Volcanic::Authenticator
 
       def initialize(stack_id: '*', dataset_id: '*', resource: '*', resource_id: nil, qualifiers: nil)
         @stack_id = stack_id
-        @dataset_id = dataset_id
+        @dataset_id = dataset_id.to_s
         @resource = resource
-        @resource_id = resource_id
+        @resource_id = resource_id.nil? ? resource_id : resource_id.to_s
         @qualifiers = qualifiers
       end
 


### PR DESCRIPTION
### What?

Found a small bug when filtering out scopes:
* Privilege#in_scope = remove the parse as it is parsed automatically.
* Cast to string for comparisons, namely around resource_id.

Previously:
```
Volcanic::Authenticator::V1::Scope.new(
  stack_id: ENV.fetch('STACK_ID'), dataset_id: dataset_id, resource: model_name, resource_id: record.id
)
```

`record.id` *may* be a string or it *may* be an integer.  However when parsing the scope from the Privilege it is parsed as a string.