### PR TITLE
AUTH-364 refactor of  add_privileges method of Role 

### DIFF
--- a/lib/volcanic/authenticator/v1/role.rb
+++ b/lib/volcanic/authenticator/v1/role.rb
@@ -74,6 +74,25 @@ module Volcanic::Authenticator
                           end
       end
 
+      def add_privileges!(*values)
+        values = values.flatten.compact
+        @privileges = nil
+        privilege_ids_tmp = @privilege_ids.dup
+        values.each do |value|
+          id = if value.is_a?(Privilege)
+                 value.id
+               else
+                 value
+               end
+
+          next if privilege_ids_tmp.include?(id)
+
+          privilege_ids_tmp << id
+        end
+        attach_privileges_ids!(privilege_ids_tmp)
+        @privilege_ids = privilege_ids_tmp
+      end
+
       def dirty?
         dirty.values.all?
       end
@@ -97,6 +116,12 @@ module Volcanic::Authenticator
         when Privilege
           @privilege_ids = privs.map(&:id)
         end
+      end
+
+      def attach_privileges_ids!(*values)
+        path = "#{self.class.path}/#{id}/privileges/attach"
+        payload = { privilege_ids: values.flatten }
+        perform_post_and_parse self.class.exception, path, payload.to_json
       end
     end
   end


### PR DESCRIPTION
Role `add_privileges` now can accept multiple values and refactor it to use the new attach api https://github.com/volcanic-uk/Authenticator/pull/248
