### PR TITLE
AUTH-648: support save principal and identity with preserve roles and privileges

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -4,4 +4,16 @@
 require 'bundler/setup'
 require 'volcanic/authenticator'
 require 'pry'
+require 'volcanic/cache'
+
+# uncomment and configure below details to test it locally
+# run bin/console at app root directory
+#
+# Volcanic::Authenticator.config do |config|
+#   config.app_dataset_id = '-1'
+#   config.app_name = 'volcanic'
+#   config.app_secret = 'volcanic!123'
+#   config.auth_url = 'http://localhost:8000'
+# end
+
 Pry.start

--- a/lib/volcanic/authenticator/v1/common.rb
+++ b/lib/volcanic/authenticator/v1/common.rb
@@ -144,22 +144,25 @@ module Volcanic::Authenticator
           end
         end
 
-        def find_by_id(id)
+        def find_by_id(id, **opts)
           raise ArgumentError, 'id is empty or nil' if id.nil? || id == ''
 
-          parsed = perform_get_and_parse exception, "#{path}/#{id}"
+          parsed = perform_get_and_parse exception, "#{path}/#{id}?#{query_params(opts)}"
           new(parsed.transform_keys!(&:to_sym))
         end
 
         private
 
         def find_with(**opts)
-          params = opts.map { |key, val| "#{key}=#{CGI.escape(val.to_s)}" }.join('&') # convert to query string
-          url = "#{path}?#{params}"
+          url = "#{path}?#{query_params(opts)}"
           parsed = perform_get_and_parse exception, url
           page_information = parsed['pagination'].transform_keys(&:to_sym)
           Collection.from_auth_service(parsed['data'].map { |d| new(d.transform_keys(&:to_sym)) },
                                        page_information) # return as collections (object array)
+        end
+
+        def query_params(**opts)
+          opts.map { |key, val| "#{key}=#{CGI.escape(val.to_s)}" }.join('&') # convert to query string
         end
       end
     end

--- a/lib/volcanic/authenticator/v1/helper/error.rb
+++ b/lib/volcanic/authenticator/v1/helper/error.rb
@@ -85,6 +85,10 @@ module Volcanic::Authenticator
       def raise_not_implemented_error(method_name)
         raise NotImplementedError, "#{method_name} must be defined by child classes"
       end
+
+      def raise_type_error(method_name, exp_type, received)
+        raise TypeError, "#{method_name} must be a #{exp_type}, but received #{received}"
+      end
     end
   end
 end

--- a/lib/volcanic/authenticator/v1/identity.rb
+++ b/lib/volcanic/authenticator/v1/identity.rb
@@ -7,8 +7,8 @@ module Volcanic::Authenticator
   module V1
     # Identity API
     class Identity < CommonPrincipalIdentity
-      attr_accessor :id, :name, :secret, :privilege_ids, :role_ids
-      attr_reader :secure_id, :principal_id, :dataset_id, :source, :created_at, :updated_at, :stack_id
+      attr_accessor :id, :name, :secret
+      attr_reader :secure_id, :principal_id, :dataset_id, :source, :privilege_ids, :role_ids, :created_at, :updated_at, :stack_id
 
       # identity base path
       def self.path
@@ -21,7 +21,7 @@ module Volcanic::Authenticator
       end
 
       def initialize(**opts)
-        %i[id secure_id name secret principal_id dataset_id active source created_at updated_at stack_id].each do |key|
+        %i[id secure_id name secret principal_id dataset_id privilege_ids role_ids active source created_at updated_at stack_id].each do |key|
           instance_variable_set("@#{key}", opts[key])
         end
       end
@@ -35,7 +35,7 @@ module Volcanic::Authenticator
       #
       # NOTE: Only use for updating identity. Not creating
       def save
-        super name: name
+        super name: name, privileges: privilege_ids, roles: role_ids
       end
 
       # reset secret

--- a/lib/volcanic/authenticator/v1/principal.rb
+++ b/lib/volcanic/authenticator/v1/principal.rb
@@ -5,9 +5,10 @@ require_relative 'common_principal_identity'
 module Volcanic::Authenticator
   module V1
     # Principal api
+    # TODO: principal_spec is missing!
     class Principal < CommonPrincipalIdentity
-      attr_reader :created_at, :updated_at
-      attr_accessor :id, :secure_id, :name, :dataset_id, :role_ids, :privilege_ids, :stack_id
+      attr_reader :created_at, :updated_at, :privilege_ids, :role_ids
+      attr_accessor :id, :secure_id, :name, :dataset_id, :stack_id
 
       # Principal end-point
       def self.path
@@ -20,7 +21,7 @@ module Volcanic::Authenticator
       end
 
       def initialize(**opts)
-        %i[id secure_id name dataset_id active created_at updated_at stack_id].each do |key|
+        %i[id secure_id name dataset_id role_ids privilege_ids active created_at updated_at stack_id].each do |key|
           instance_variable_set("@#{key}", opts[key])
         end
       end
@@ -32,7 +33,7 @@ module Volcanic::Authenticator
       #   principal.save
       #
       def save
-        payload = { name: name }
+        payload = { name: name, privileges: privilege_ids, roles: role_ids }
         super payload
       end
 


### PR DESCRIPTION
JIRA: https://volcanicuk.atlassian.net/browse/AUTH-648

calling `.save` to identity or principal will preserve the privileges and roles unless it changes

example:

```ruby
principal = Vol::Auth::V1::Principal.find_by_id('volcanic')
principal.name = 'new-name'
principal.save. # send to auth service with name, privileges and roles
```

this PR is depends on https://github.com/volcanic-uk/Authenticator/pull/288